### PR TITLE
Adding deleteData and getDataWithFallback methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flywheelsports/cacher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A caching module for use with Node and Redis",
   "author": {
     "name": "Carlos Justiniano",


### PR DESCRIPTION
- `deleteData` takes a key and uses the redis `DEL` command to delete that cache key
- `getDataWithFallback` takes a key, cache expiration, and fallback method and is a convenience method for a common use case I've come across - reading something from cache, and then falling back to another data source (like the DB) and caching that result
  - We had a similar method before, and I know we had some reservations about it, but I think that it's useful for keeping "user" code simpler, and am happy to discuss merits / downsides
