### PR TITLE
use fwsp-redis-connection module to connect to redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Promise = require('bluebird');
-const redis = require('redis');
 const utils = require('fwsp-jsutils');
+const RedisConnection = require('fwsp-redis-connection');
 
 /**
  * @name cacher
@@ -32,15 +32,10 @@ class CacheDB {
   * @return {object} promise - resolving or rejecting if error
   */
   openDB() {
-    let db = redis.createClient(
-      this.config.port,
-      this.config.url,
-      null);
-    return new Promise((resolve, reject) => {
-      db.select(this.config.db, (err, reply) => {
-        (err) ? reject(err) : resolve(db);
-      });
-    });
+    let retryStrategy = this.config.retry_strategy;
+    delete this.config.retry_strategy;
+    let redisConnection = new RedisConnection(this.config);
+    return redisConnection.connect(retryStrategy)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-cacher",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A caching module for use with Node and Redis",
   "author": {
     "name": "Carlos Justiniano",
@@ -21,9 +21,9 @@
   },
   "homepage": "https://github.com/flywheelsports/fwsp-cacher#readme",
   "dependencies": {
-    "bluebird": "^3.3.5",
-    "fwsp-jsutils": "1.0.8",
-    "redis": "^2.6.0-2"
+    "bluebird": "3.5.0",
+    "fwsp-jsutils": "1.0.10",
+    "fwsp-redis-connection": "0.0.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This fixes an issue where services pass in a redis config in the new format (url: "redis://host:port/db") and the cacher fails to connect.